### PR TITLE
게시글 리스트/조회 구현

### DIFF
--- a/src/main/java/ga/surilaw/common/mapper/CommentMapper.java
+++ b/src/main/java/ga/surilaw/common/mapper/CommentMapper.java
@@ -1,19 +1,78 @@
 package ga.surilaw.common.mapper;
 
 import ga.surilaw.domain.dto.board.InsertCommentDto;
+import ga.surilaw.domain.dto.board.InsertPostInfoDto;
+import ga.surilaw.domain.dto.board.ReadCommentDto;
 import ga.surilaw.domain.entity.Comments;
 import ga.surilaw.domain.entity.Member;
 import ga.surilaw.domain.entity.PostInformation;
 import org.mapstruct.*;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Mapper(componentModel = "spring")
 public interface CommentMapper {
 
-    default Comments insertDtotoEntity(InsertCommentDto insertCommentDto, Member member, PostInformation postInformation){
+    default Comments insertDtoToEntity(InsertCommentDto insertCommentDto, Member member, PostInformation postInformation){
         Comments comments = Comments.builder().commentContent(insertCommentDto.getContent()).build();
         comments.changeMember(member);
         postInformation.addComment(comments);
         return comments;
     }
+
+    default ReadCommentDto readEntityToDto(Comments comments){
+        if ( comments == null ) {
+            return null;
+        }
+
+        ReadCommentDto readCommentDto = new ReadCommentDto();
+        readCommentDto.setCommentId( comments.getCommentId() );
+        if(comments.getCommentContent() != null){
+            readCommentDto.setComment(comments.getCommentContent());
+        }else {
+            readCommentDto.setComment("삭제된 댓글입니다.");
+        }
+
+        readCommentDto.setMemberId( commentsMemberMemberId( comments ) );
+        readCommentDto.setMemberName( commentsMemberMemberName( comments ) );
+        readCommentDto.setCreatedDate(comments.getCreatedDate());
+
+        return readCommentDto;
+    }
+
+    private String commentsMemberMemberId(Comments comments) {
+        Member member = comments.getMember();
+        if ( member == null ) {
+            return null;
+        }
+        return member.getMemberId();
+    }
+
+    private String commentsMemberMemberName(Comments comments) {
+        Member member = comments.getMember();
+        if ( member == null ) {
+            return null;
+        }
+        String memberName = member.getMemberName();
+        if ( memberName == null ) {
+            return null;
+        }
+        return memberName;
+    }
+
+    default ReadCommentDto readEntityToDtoChild(Comments comments){
+        ReadCommentDto commentDto = readEntityToDto(comments);
+
+        if(comments.getChild() != null){
+            commentDto.setChilds(
+                    comments.getChild().stream()
+                            .map(m -> readEntityToDto(m))
+                            .collect(Collectors.toList()));
+        }
+        return commentDto;
+    }
+
+
 
 }

--- a/src/main/java/ga/surilaw/common/mapper/PostInfoMapper.java
+++ b/src/main/java/ga/surilaw/common/mapper/PostInfoMapper.java
@@ -31,13 +31,6 @@ public interface PostInfoMapper {
         }
         return postInformation;
     }
-
-
-    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
-    @Mapping(source = "member.memberName", target = "memberName")
-    @Mapping(source = "postTitle", target = "title")
-    @Mapping(source = "postContent", target = "content")
-    ReadPostInfoDto entityToReadDto(PostInformation postInformation);
 }
 
 

--- a/src/main/java/ga/surilaw/controller/board/BoardController.java
+++ b/src/main/java/ga/surilaw/controller/board/BoardController.java
@@ -2,6 +2,7 @@ package ga.surilaw.controller.board;
 
 import ga.surilaw.common.mapper.PostInfoMapper;
 import ga.surilaw.domain.dto.board.InsertPostInfoDto;
+import ga.surilaw.domain.dto.board.pagination.PageableDto;
 import ga.surilaw.service.board.BoardService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -36,6 +37,10 @@ public class BoardController {
         boardService.delete(postId);
     }
 
+    @GetMapping("/api/board/list")
+    public ResponseEntity<?> readPostList(@ModelAttribute PageableDto pageableDto){
+        return ResponseEntity.ok(boardService.readList(pageableDto));
+    }
 
     @GetMapping("/api/board/{postId}")
     public ResponseEntity<?> readPost(@PathVariable(name = "postId") Long postId){

--- a/src/main/java/ga/surilaw/controller/board/BoardController.java
+++ b/src/main/java/ga/surilaw/controller/board/BoardController.java
@@ -39,8 +39,7 @@ public class BoardController {
 
     @GetMapping("/api/board/{postId}")
     public ResponseEntity<?> readPost(@PathVariable(name = "postId") Long postId){
-        //mapper + memberId -> memberName으로의 변환 필요
-        boardService.read(postId);
+        //mapper + memberId -> memberName? or 반정규화
         return ResponseEntity.ok(boardService.read(postId));
     }
 }

--- a/src/main/java/ga/surilaw/controller/board/CommentController.java
+++ b/src/main/java/ga/surilaw/controller/board/CommentController.java
@@ -25,4 +25,5 @@ public class CommentController {
         commentService.deleteComment(commentId);
     }
 
+
 }

--- a/src/main/java/ga/surilaw/domain/dto/Board/ReadCommentDto.java
+++ b/src/main/java/ga/surilaw/domain/dto/Board/ReadCommentDto.java
@@ -1,0 +1,22 @@
+package ga.surilaw.domain.dto.board;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ReadCommentDto {
+    private Long commentId;
+    private String comment;
+    private String memberId;
+    private String memberName;
+    private LocalDateTime createdDate;
+    private List<ReadCommentDto> childs;
+}
+

--- a/src/main/java/ga/surilaw/domain/dto/Board/ReadPostInfoDto.java
+++ b/src/main/java/ga/surilaw/domain/dto/Board/ReadPostInfoDto.java
@@ -1,16 +1,34 @@
 package ga.surilaw.domain.dto.board;
 
+import ga.surilaw.domain.entity.enumType.Category;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 public class ReadPostInfoDto {
     private Long postId;
-    private String memberName;
-    private String category;
+    private String userId;
+    private String userName;
+    private String type;
     private String title;
     private String content;
+    private LocalDateTime createdDate;
+    private List<ReadCommentDto> comments;
+
+    public ReadPostInfoDto (Long postId, String userId,String userName,
+                            Category category, String title, String content, LocalDateTime createdDate){
+        this.postId = postId;
+        this.userId = userId;
+        this.userName = userName;
+        this.type = category.getValue();
+        this.title = title;
+        this.content = content;
+        this.createdDate = createdDate;
+    }
 }

--- a/src/main/java/ga/surilaw/domain/dto/Board/ReadPostListDto.java
+++ b/src/main/java/ga/surilaw/domain/dto/Board/ReadPostListDto.java
@@ -1,0 +1,17 @@
+package ga.surilaw.domain.dto.board;
+
+import ga.surilaw.domain.dto.board.pagination.PageInfoDto;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ReadPostListDto extends PageInfoDto {
+    List<ReadPostShortDto> postList;
+    int totalElements;
+    String sort;
+}

--- a/src/main/java/ga/surilaw/domain/dto/Board/ReadPostShortDto.java
+++ b/src/main/java/ga/surilaw/domain/dto/Board/ReadPostShortDto.java
@@ -1,0 +1,17 @@
+package ga.surilaw.domain.dto.board;
+
+import com.querydsl.jpa.impl.JPAUtil;
+import ga.surilaw.domain.entity.enumType.Category;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ReadPostShortDto {
+    public Long id;
+    public String memberName;
+    public String contentTitle;
+    public Category category;
+}

--- a/src/main/java/ga/surilaw/domain/dto/Board/pagination/FilterDto.java
+++ b/src/main/java/ga/surilaw/domain/dto/Board/pagination/FilterDto.java
@@ -1,0 +1,24 @@
+package ga.surilaw.domain.dto.board.pagination;
+
+import ga.surilaw.domain.entity.enumType.Category;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+public class FilterDto {
+    Category category;
+    String name;
+    String title;
+    String content;
+
+    public FilterDto(String category, String name, String title, String content){
+        this.category = Category.valueOf(category);
+        this.name = name;
+        this.title = title;
+        this.content =content;
+    }
+}

--- a/src/main/java/ga/surilaw/domain/dto/Board/pagination/PageInfoDto.java
+++ b/src/main/java/ga/surilaw/domain/dto/Board/pagination/PageInfoDto.java
@@ -1,0 +1,15 @@
+package ga.surilaw.domain.dto.board.pagination;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PageInfoDto {
+    int totalPages;
+    int page;
+    int size;
+    String order;
+}

--- a/src/main/java/ga/surilaw/domain/dto/Board/pagination/PageableDto.java
+++ b/src/main/java/ga/surilaw/domain/dto/Board/pagination/PageableDto.java
@@ -1,0 +1,41 @@
+package ga.surilaw.domain.dto.board.pagination;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.HashMap;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PageableDto {
+
+    int page = 0;
+    int size = 20;
+
+    //나중에 sort Setting 추가해야함.
+    String sort = "postId";
+
+    //ASC or DESC
+    String order;
+
+    //filter String
+    String filter;
+
+    FilterDto filters;
+
+    public void setFilters(){
+        String[] parse = filter.split(",");
+
+        HashMap<String, String> parseMap =  new HashMap<>();
+
+        for(String s : parse){
+            String[] token = s.split(":");
+            parseMap.put(token[0],token[1]);
+        }
+
+        filters = new FilterDto(parseMap.get("category"),
+                parseMap.get("name"), parseMap.get("title"),parseMap.get("content"));
+    }
+}

--- a/src/main/java/ga/surilaw/domain/entity/Comments.java
+++ b/src/main/java/ga/surilaw/domain/entity/Comments.java
@@ -70,6 +70,7 @@ public class Comments extends BaseEntity{
     public void addParent(Comments parentComment){
         //자식한테 부모 추가
         this.parent = parentComment;
+        this.child = null; //자식이 있을 수 없음.
 
         //부모한테는 자식 추가
         parentComment.getChild().add(this);

--- a/src/main/java/ga/surilaw/domain/entity/PostInformation.java
+++ b/src/main/java/ga/surilaw/domain/entity/PostInformation.java
@@ -2,7 +2,6 @@ package ga.surilaw.domain.entity;
 
 import ga.surilaw.domain.entity.enumType.Category;
 import lombok.*;
-import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicUpdate;
 
 import javax.persistence.*;

--- a/src/main/java/ga/surilaw/repository/board/BoardRepositorySupport.java
+++ b/src/main/java/ga/surilaw/repository/board/BoardRepositorySupport.java
@@ -1,11 +1,15 @@
 package ga.surilaw.repository.board;
 
 import ga.surilaw.domain.dto.board.ReadPostInfoDto;
+import ga.surilaw.domain.dto.board.ReadPostListDto;
+import ga.surilaw.domain.dto.board.pagination.FilterDto;
 import ga.surilaw.domain.entity.Comments;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface BoardRepositorySupport {
     ReadPostInfoDto readPost(Long postId);
     List<Comments> readComment(Long postId);
+    ReadPostListDto getPageList(FilterDto filter, Pageable pageable);
 }

--- a/src/main/java/ga/surilaw/repository/board/BoardRepositorySupport.java
+++ b/src/main/java/ga/surilaw/repository/board/BoardRepositorySupport.java
@@ -1,6 +1,11 @@
 package ga.surilaw.repository.board;
 
-import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+import ga.surilaw.domain.dto.board.ReadPostInfoDto;
+import ga.surilaw.domain.entity.Comments;
+
+import java.util.List;
 
 public interface BoardRepositorySupport {
+    ReadPostInfoDto readPost(Long postId);
+    List<Comments> readComment(Long postId);
 }

--- a/src/main/java/ga/surilaw/repository/board/BoardRepositorySupportImpl.java
+++ b/src/main/java/ga/surilaw/repository/board/BoardRepositorySupportImpl.java
@@ -1,15 +1,60 @@
 package ga.surilaw.repository.board;
 
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.JPQLQuery;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import ga.surilaw.domain.entity.PostInformation;
+import ga.surilaw.domain.dto.board.ReadPostInfoDto;
+import ga.surilaw.domain.entity.*;
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+import org.springframework.stereotype.Repository;
 
+import javax.persistence.EntityGraph;
+import javax.persistence.EntityManager;
+import java.util.List;
+
+@Repository
 public class BoardRepositorySupportImpl extends QuerydslRepositorySupport implements BoardRepositorySupport {
 
     private final JPAQueryFactory queryFactory;
+    private final EntityManager em;
 
-    public BoardRepositorySupportImpl(JPAQueryFactory queryFactory) {
+    public BoardRepositorySupportImpl(JPAQueryFactory queryFactory, EntityManager em) {
         super(PostInformation.class);
         this.queryFactory = queryFactory;
+        this.em = em;
     }
+
+    public ReadPostInfoDto readPost(Long postId){
+        QPostInformation postInformation = QPostInformation.postInformation;
+
+        return queryFactory.from(postInformation).select(Projections.constructor(ReadPostInfoDto.class,
+                postInformation.postId,
+                postInformation.member.memberId,
+                postInformation.member.memberName,
+                postInformation.category,
+                postInformation.postTitle,
+                postInformation.postContent,
+                postInformation.createdDate
+        ))
+                .where(postInformation.postId.eq(postId)).fetchOne();
+    }
+
+    public List<Comments> readComment(Long postId){
+        QComments parent = new QComments("parent");
+        QComments child = new QComments("child");
+
+
+        JPAQuery<Comments> query = queryFactory.from(parent)
+                .select(parent)
+                .where(parent.posts.postId.eq(postId)
+                        .and(parent.parent.isNull()))
+                .leftJoin(parent.child,child)
+                .fetchJoin()
+                .distinct();
+
+
+        return query.fetch();
+    }
+
 }

--- a/src/main/java/ga/surilaw/repository/board/BoardRepositorySupportImpl.java
+++ b/src/main/java/ga/surilaw/repository/board/BoardRepositorySupportImpl.java
@@ -44,7 +44,6 @@ public class BoardRepositorySupportImpl extends QuerydslRepositorySupport implem
         QComments parent = new QComments("parent");
         QComments child = new QComments("child");
 
-
         JPAQuery<Comments> query = queryFactory.from(parent)
                 .select(parent)
                 .where(parent.posts.postId.eq(postId)

--- a/src/main/java/ga/surilaw/service/board/BoardService.java
+++ b/src/main/java/ga/surilaw/service/board/BoardService.java
@@ -2,6 +2,8 @@ package ga.surilaw.service.board;
 
 import ga.surilaw.domain.dto.board.InsertPostInfoDto;
 import ga.surilaw.domain.dto.board.ReadPostInfoDto;
+import ga.surilaw.domain.dto.board.ReadPostListDto;
+import ga.surilaw.domain.dto.board.pagination.PageableDto;
 import ga.surilaw.domain.entity.PostInformation;
 
 public interface BoardService {
@@ -9,4 +11,5 @@ public interface BoardService {
     Long update(InsertPostInfoDto insertPostInfoDto);
     void delete(Long postId);
     ReadPostInfoDto read(Long postId);
+    ReadPostListDto readList(PageableDto pageableDto);
 }

--- a/src/main/java/ga/surilaw/service/board/BoardService.java
+++ b/src/main/java/ga/surilaw/service/board/BoardService.java
@@ -1,11 +1,12 @@
 package ga.surilaw.service.board;
 
 import ga.surilaw.domain.dto.board.InsertPostInfoDto;
+import ga.surilaw.domain.dto.board.ReadPostInfoDto;
 import ga.surilaw.domain.entity.PostInformation;
 
 public interface BoardService {
     Long write(InsertPostInfoDto insertPostInfoDto);
     Long update(InsertPostInfoDto insertPostInfoDto);
     void delete(Long postId);
-    PostInformation read(Long postId);
+    ReadPostInfoDto read(Long postId);
 }

--- a/src/main/java/ga/surilaw/service/board/BoardServiceImpl.java
+++ b/src/main/java/ga/surilaw/service/board/BoardServiceImpl.java
@@ -5,6 +5,9 @@ import ga.surilaw.common.mapper.PostInfoMapper;
 import ga.surilaw.domain.dto.board.InsertPostInfoDto;
 import ga.surilaw.domain.dto.board.ReadCommentDto;
 import ga.surilaw.domain.dto.board.ReadPostInfoDto;
+import ga.surilaw.domain.dto.board.ReadPostListDto;
+import ga.surilaw.domain.dto.board.pagination.FilterDto;
+import ga.surilaw.domain.dto.board.pagination.PageableDto;
 import ga.surilaw.domain.entity.Comments;
 import ga.surilaw.domain.entity.Member;
 import ga.surilaw.domain.entity.PostInformation;
@@ -14,9 +17,14 @@ import ga.surilaw.repository.board.PostInfoRepository;
 import ga.surilaw.repository.member.MemberRepository;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 
 @Service
@@ -70,5 +78,29 @@ public class BoardServiceImpl implements BoardService{
         readPostInfoDto.setComments(readCommentDto);
         System.out.println(readPostInfoDto);
         return readPostInfoDto;
+    }
+
+    public ReadPostListDto readList(PageableDto pageableDto){
+
+        //Pageable Setting
+        Pageable pageable = PageRequest.of(pageableDto.getPage(),
+                pageableDto.getSize(),
+                getSortOrders(pageableDto.getOrder(), pageableDto.getSort()));
+
+        //Filter Setting
+        if(StringUtils.hasLength(pageableDto.getFilter())){
+            pageableDto.setFilters();
+        }
+
+        return boardRepositorySupport.getPageList(pageableDto.getFilters(), pageable);
+    }
+
+    private Sort getSortOrders(String order,String sort){
+        if(StringUtils.hasLength(order)){
+            if(order.toUpperCase(Locale.ROOT).equals("DESC")){
+                return Sort.by(Sort.Direction.DESC, sort);
+            }
+        }
+        return Sort.by(Sort.Direction.ASC, sort);
     }
 }

--- a/src/main/java/ga/surilaw/service/board/BoardServiceImpl.java
+++ b/src/main/java/ga/surilaw/service/board/BoardServiceImpl.java
@@ -1,14 +1,23 @@
 package ga.surilaw.service.board;
 
+import ga.surilaw.common.mapper.CommentMapper;
 import ga.surilaw.common.mapper.PostInfoMapper;
 import ga.surilaw.domain.dto.board.InsertPostInfoDto;
+import ga.surilaw.domain.dto.board.ReadCommentDto;
+import ga.surilaw.domain.dto.board.ReadPostInfoDto;
+import ga.surilaw.domain.entity.Comments;
 import ga.surilaw.domain.entity.Member;
 import ga.surilaw.domain.entity.PostInformation;
+import ga.surilaw.repository.board.BoardRepositorySupport;
+import ga.surilaw.repository.board.CommentRepository;
 import ga.surilaw.repository.board.PostInfoRepository;
 import ga.surilaw.repository.member.MemberRepository;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -17,6 +26,11 @@ public class BoardServiceImpl implements BoardService{
     private final PostInfoRepository postInfoRepository;
     private final MemberRepository memberRepository;
     private final PostInfoMapper postInfoMapper;
+
+    private final BoardRepositorySupport boardRepositorySupport;
+    private final CommentMapper commentsMapper;
+
+    //custom
 
     @Override
     public Long write(InsertPostInfoDto insertPostInfoDto) {
@@ -41,7 +55,20 @@ public class BoardServiceImpl implements BoardService{
         postInfoRepository.deleteById(postId);
     }
 
-    public PostInformation read(Long postId){
-        return postInfoRepository.findById(postId).orElseThrow();
+    public ReadPostInfoDto read(Long postId){
+
+        ReadPostInfoDto readPostInfoDto = boardRepositorySupport.readPost(postId);
+
+        //일단 다 땡겨오기
+        List<Comments> comments = boardRepositorySupport.readComment(postId);
+
+        //이후 매핑
+        List<ReadCommentDto> readCommentDto  = comments.stream().map(
+                m-> commentsMapper.readEntityToDtoChild(m))
+                .collect(Collectors.toList());
+
+        readPostInfoDto.setComments(readCommentDto);
+        System.out.println(readPostInfoDto);
+        return readPostInfoDto;
     }
 }

--- a/src/main/java/ga/surilaw/service/board/CommentServiceImpl.java
+++ b/src/main/java/ga/surilaw/service/board/CommentServiceImpl.java
@@ -11,8 +11,6 @@ import ga.surilaw.repository.member.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.Optional;
-
 @RequiredArgsConstructor
 @Service
 public class CommentServiceImpl implements CommentService{
@@ -29,7 +27,7 @@ public class CommentServiceImpl implements CommentService{
         //Mapping
         Member member = memberRepository.getById(insertCommentDto.getMemberId());
         PostInformation post = postInfoRepository.getById(insertCommentDto.getPostId());
-        Comments comments = commentMapper.insertDtotoEntity(insertCommentDto, member, post);
+        Comments comments = commentMapper.insertDtoToEntity(insertCommentDto, member, post);
 
         //루트가 아니면 부모랑도 연결
         if(insertCommentDto.getParentId() != null){

--- a/src/test/java/ga/surilaw/repository/board/BoardRepositorySupportImplTest.java
+++ b/src/test/java/ga/surilaw/repository/board/BoardRepositorySupportImplTest.java
@@ -1,0 +1,108 @@
+package ga.surilaw.repository.board;
+
+import ga.surilaw.domain.dto.board.ReadPostInfoDto;
+import ga.surilaw.domain.entity.Comments;
+import ga.surilaw.domain.entity.Member;
+import ga.surilaw.domain.entity.PostInformation;
+import ga.surilaw.domain.entity.enumType.Category;
+import ga.surilaw.repository.member.MemberRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+@SpringBootTest
+@Transactional
+@Rollback(value = false)
+class BoardRepositorySupportImplTest {
+
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired PostInfoRepository postInfoRepository;
+    @Autowired CommentRepository commentRepository;
+
+    @Autowired BoardRepositorySupport boardRepositorySupport;
+    @Autowired EntityManager em;
+    @Test
+    public void readPost(){
+        //given
+        Member member = insertMember();
+        PostInformation postInformation = insertPostinformation(member);
+        em.flush();
+        em.clear();
+
+        //when
+        ReadPostInfoDto readPostInfoDto = boardRepositorySupport.readPost(postInformation.getPostId());
+
+        //then
+        Assertions.assertThat(readPostInfoDto.getPostId()).isEqualTo(postInformation.getPostId());
+        Assertions.assertThat(readPostInfoDto.getUserName()).isEqualTo(member.getMemberName());
+    }
+    
+    @Test
+    public void readComment() throws Exception{
+        //given
+        Member member = insertMember();
+        PostInformation postInformation = insertPostinformation(member);
+        Comments comments = insertComments(member,postInformation);
+
+        addChild(member, postInformation, comments, 10);
+
+        //when
+        List<Comments> commentLists = boardRepositorySupport.readComment(postInformation.getPostId());
+
+        //then
+        Assertions.assertThat(commentLists.size()).isEqualTo(1); //기본자식은 하나
+        Assertions.assertThat(commentLists.get(0).getCommentContent()).isEqualTo(comments.getCommentContent());
+        Assertions.assertThat(commentLists.get(0).getChild().size()).isEqualTo(10); //대댓글 10개
+        Assertions.assertThat(commentLists.get(0).getChild().get(5).getCommentContent()).isEqualTo(comments.getChild().get(5).getCommentContent());
+    }
+
+    public void addChild(Member member, PostInformation postInformation, Comments parent, int times){
+        for(int i=0; i<times; i++){
+            Comments c =   Comments.builder()
+                    .posts(postInformation)
+                    .member(member)
+                    .commentContent("Test Content Child"+i)
+                    .isDeleted(false)
+                    .isAnswerExists(false)
+                    .build();
+            c.addParent(parent);
+            commentRepository.save(c);
+        }
+    }
+    
+    public Member insertMember(){
+        Member member = new Member("sample@abc.abc","테스트","1234",'C');
+        return memberRepository.save(member);
+    }
+    
+    public PostInformation insertPostinformation(Member member){
+        PostInformation postInformation = PostInformation.builder()
+                .category(Category.INFO)
+                .member(member)
+                .postTitle("TestTitle")
+                .postContent("Test Content")
+                .build();
+        return postInfoRepository.save(postInformation);
+    }
+
+    public Comments insertComments(Member member, PostInformation postInformation){
+        Comments comments = Comments.builder()
+                .posts(postInformation)
+                .member(member)
+                .commentContent("Test Content")
+                .isDeleted(false)
+                .isAnswerExists(false)
+                .build();
+
+        return commentRepository.save(comments);
+    }
+
+
+}

--- a/src/test/java/ga/surilaw/repository/board/CommentRepositoryTest.java
+++ b/src/test/java/ga/surilaw/repository/board/CommentRepositoryTest.java
@@ -59,6 +59,4 @@ class CommentRepositoryTest {
         assertThat(findComments.getCommentId()).isEqualTo(findComments.getCommentId());
         assertThat(findComments).isEqualTo(savedComments);
     }
-
-
 }

--- a/src/test/java/ga/surilaw/service/board/CommentServiceTest.java
+++ b/src/test/java/ga/surilaw/service/board/CommentServiceTest.java
@@ -11,7 +11,6 @@ import ga.surilaw.repository.member.MemberRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.Rollback;
 
 import javax.transaction.Transactional;
 


### PR DESCRIPTION
문제)  게시글 개별 조회의 경우 회원 이름 조회 시 N+1 발생
-> 게시글 / 댓글에 MemberName을 반정규화 문의 (어차피 매번 같이 씀)

문제2) JPA Entity를 사용하면, Sort 조건이 클래스의 필드명을 문자열로 넣어줘야함. 
-> 미리 정의해야 하는 필요성이 있을 것 같음

Pagingation에서 totalCount를 조회하기 위해 한번 더 count 쿼리를 날려야 함
복잡한 검색 조건일 때 성능이 떨어질 것 같음